### PR TITLE
Feature/ignore environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ You also can change default MOTD (default is `:base_jumper`):
 set :friday_motd, :flipping_table
 ```
 
+Ignore environments, so not as to punish the testing of code
+
+```ruby
+set :friday_ingnore_env, [:staging]
+```
+
 **TODO:** need to add many more MOTDs!
 
 ## Contributing

--- a/capistrano-friday.gemspec
+++ b/capistrano-friday.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "capistrano-friday"
-  spec.version       = '0.0.2'
+  spec.version       = '0.0.3'
   spec.authors       = ["Vladimir Kochnev"]
   spec.email         = ["hashtable@yandex.ru"]
   spec.summary       = %q{You better stab yourself if you deploy on friday!}

--- a/lib/capistrano/tasks/friday.rake
+++ b/lib/capistrano/tasks/friday.rake
@@ -21,7 +21,10 @@ namespace :friday do
   }
 
   task :check do
-    invoke 'friday:good_luck' if Time.now.friday?
+    ignore = fetch :friday_ignore_env
+    unless ignore.include?(fetch(:stage))
+      invoke 'friday:good_luck' if Time.now.friday?
+    end
   end
 
   task :good_luck do
@@ -40,5 +43,6 @@ namespace :load do
   task :defaults do
     set :friday_motd, :base_jumper
     set :friday_disable_deploy, false
+    set :friday_ignore_env, [:staging]
   end
 end


### PR DESCRIPTION
While I find this wonderful addition to Capistrano hilarious, I don't want my fellow devs feeling that something is wrong deploying to a stage server o a Friday.

By default this will ignore the `:staging` environment, but can be expanded to more custom environments if people wish.
